### PR TITLE
fix: Windows compatibility during initialization

### DIFF
--- a/nox.py
+++ b/nox.py
@@ -178,15 +178,19 @@ def initialize_environment() -> None:
     for d in (HOME_NOX, LOG_DIR, REPORT_DIR, SOURCE_DIR, VAULT_DIR, PROVIDER_DIR):
         d.mkdir(mode=0o755, parents=True, exist_ok=True)
 
-    # Ownership fix: if run as root previously, re-own to the real user
-    real_uid = int(os.environ.get("SUDO_UID", os.getuid()))
-    real_gid = int(os.environ.get("SUDO_GID", os.getgid()))
-    if os.getuid() == 0 and real_uid != 0:
-        for d in (HOME_NOX, LOG_DIR, REPORT_DIR, SOURCE_DIR, VAULT_DIR):
-            try:
-                os.chown(d, real_uid, real_gid)
-            except OSError:
-                pass
+    # Ownership fix: if run as root previously, re-own to the real user (POSIX only)
+    if hasattr(os, "getuid") and hasattr(os, "getgid") and hasattr(os, "chown"):
+        try:
+            real_uid = int(os.environ.get("SUDO_UID", os.getuid()))
+            real_gid = int(os.environ.get("SUDO_GID", os.getgid()))
+            if os.getuid() == 0 and real_uid != 0:
+                for d in (HOME_NOX, LOG_DIR, REPORT_DIR, SOURCE_DIR, VAULT_DIR):
+                    try:
+                        os.chown(d, real_uid, real_gid)
+                    except OSError:
+                        pass
+        except Exception:
+            pass
 
     # Create default config.ini on first run
     _default_cfg = HOME_NOX / "config.ini"


### PR DESCRIPTION
## Problem

When importing or executing 
ox.py on Windows (which many users will try when pulling the project directly as a script without Docker/WSL), the initialization fails immediately because os.getuid() and os.getgid() are POSIX-only functions and raise an AttributeError on Windows.

## Solution

Wrapped the initialization logic that attempts to fix UNIX file ownership (if run under sudo) in a feature check:
``python
if hasattr(os, "getuid") and hasattr(os, "getgid") and hasattr(os, "chown"):
``

This prevents Windows imports from instantly crashing with an AttributeError.

## PR Checklist

- [x] `python3 -m py_compile nox.py` passes
- [x] Python 3.8+ compatible
- [x] No credentials or personal data in the diff
